### PR TITLE
[BUGFIX] Environmental variables not set in run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV INSTALL_TOOL_PASSWORD password
 ENV TYPO3_COMPOSER_AUTOLOAD 1
 
 EXPOSE 80
-CMD ["/bin/bash", "-c", "/run-typo3.sh && /run.sh"]
+CMD ["/bin/bash", "-c", "/run-typo3.sh"]

--- a/run-typo3.sh
+++ b/run-typo3.sh
@@ -71,3 +71,7 @@ if [ ! -f /app/typo3conf/LocalConfiguration.php ]
         echo "Set permissions for /app folder ..."
         chown www-data:www-data -R /app/fileadmin /app/typo3temp /app/uploads
 fi
+
+# Start apache in foreground
+/run.sh
+


### PR DESCRIPTION
The DB_HOST and DB_PORT shell variables will not get passed on to
the run.sh script chained with the bash "&&" operator. For this
reason the DB_HOST and DB_PORT environment variables were not
accessible to the "getenv()" in AdditionalConfiguration.php

The solution is to only execute "run-typo3.sh" from within the
Dockerfile and start "run.sh" from within "run-typo3.sh". By this
change the "run.sh" gets executed from within the environment
context of "run-typo3.sh" in which the mentioned variables are set.

Fixes: #2
